### PR TITLE
[feature] view간의 이동 상세 구현

### DIFF
--- a/K-Market/K-Market.xcodeproj/project.pbxproj
+++ b/K-Market/K-Market.xcodeproj/project.pbxproj
@@ -33,6 +33,11 @@
 		3C23C30E29BC1EE000802CEC /* DecodeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C23C30D29BC1EE000802CEC /* DecodeManager.swift */; };
 		3C244F7F29C820A2007FCA2E /* ServiceDIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C244F7E29C820A2007FCA2E /* ServiceDIContainer.swift */; };
 		3C244F8129C820F5007FCA2E /* SceneDIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C244F8029C820F5007FCA2E /* SceneDIContainer.swift */; };
+		3C244F8629C8458A007FCA2E /* Coordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C244F8529C8458A007FCA2E /* Coordinator.swift */; };
+		3C244F8829C845BF007FCA2E /* ListCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C244F8729C845BF007FCA2E /* ListCoordinator.swift */; };
+		3C244F8A29C845D4007FCA2E /* DetailCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C244F8929C845D4007FCA2E /* DetailCoordinator.swift */; };
+		3C244F8C29C845F2007FCA2E /* AddCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C244F8B29C845F2007FCA2E /* AddCoordinator.swift */; };
+		3C244F8E29C84605007FCA2E /* EditCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C244F8D29C84605007FCA2E /* EditCoordinator.swift */; };
 		3C28EF1829C0B86D00F60F2D /* UILabel+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C28EF1729C0B86D00F60F2D /* UILabel+Extension.swift */; };
 		3C40159829C1AD23007448A8 /* HeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C40159729C1AD23007448A8 /* HeaderView.swift */; };
 		3C40159B29C2E92C007448A8 /* Observabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C40159A29C2E92C007448A8 /* Observabel.swift */; };
@@ -118,6 +123,11 @@
 		3C23C30D29BC1EE000802CEC /* DecodeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecodeManager.swift; sourceTree = "<group>"; };
 		3C244F7E29C820A2007FCA2E /* ServiceDIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceDIContainer.swift; sourceTree = "<group>"; };
 		3C244F8029C820F5007FCA2E /* SceneDIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDIContainer.swift; sourceTree = "<group>"; };
+		3C244F8529C8458A007FCA2E /* Coordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coordinator.swift; sourceTree = "<group>"; };
+		3C244F8729C845BF007FCA2E /* ListCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListCoordinator.swift; sourceTree = "<group>"; };
+		3C244F8929C845D4007FCA2E /* DetailCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailCoordinator.swift; sourceTree = "<group>"; };
+		3C244F8B29C845F2007FCA2E /* AddCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddCoordinator.swift; sourceTree = "<group>"; };
+		3C244F8D29C84605007FCA2E /* EditCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditCoordinator.swift; sourceTree = "<group>"; };
 		3C28EF1729C0B86D00F60F2D /* UILabel+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+Extension.swift"; sourceTree = "<group>"; };
 		3C40159729C1AD23007448A8 /* HeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderView.swift; sourceTree = "<group>"; };
 		3C40159A29C2E92C007448A8 /* Observabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Observabel.swift; sourceTree = "<group>"; };
@@ -227,6 +237,7 @@
 			isa = PBXGroup;
 			children = (
 				3C244F7D29C8206A007FCA2E /* DIContainer */,
+				3C244F8429C8456C007FCA2E /* Coordinator */,
 				3C13A80829B9CC6500E2FB03 /* Util */,
 				3C13A7F629B9AD9800E2FB03 /* Application */,
 				3CB7C82029BC2CB5001E7992 /* Present */,
@@ -391,6 +402,18 @@
 				3C244F8029C820F5007FCA2E /* SceneDIContainer.swift */,
 			);
 			path = DIContainer;
+			sourceTree = "<group>";
+		};
+		3C244F8429C8456C007FCA2E /* Coordinator */ = {
+			isa = PBXGroup;
+			children = (
+				3C244F8529C8458A007FCA2E /* Coordinator.swift */,
+				3C244F8729C845BF007FCA2E /* ListCoordinator.swift */,
+				3C244F8929C845D4007FCA2E /* DetailCoordinator.swift */,
+				3C244F8B29C845F2007FCA2E /* AddCoordinator.swift */,
+				3C244F8D29C84605007FCA2E /* EditCoordinator.swift */,
+			);
+			path = Coordinator;
 			sourceTree = "<group>";
 		};
 		3C40159929C2E91A007448A8 /* Type */ = {
@@ -729,6 +752,7 @@
 				3CB4B61529C6CD1C0012BBB1 /* UploadView.swift in Sources */,
 				3CFA1E1629C5F25B0024BA3C /* UIImage+Extension.swift in Sources */,
 				3C4015A729C43D7A007448A8 /* DetailImageCell.swift in Sources */,
+				3C244F8C29C845F2007FCA2E /* AddCoordinator.swift in Sources */,
 				3CB7C82529BC31F4001E7992 /* ListViewModel.swift in Sources */,
 				3CA9B6FD29BCAB2700C3B28D /* UseIdentifiable.swift in Sources */,
 				3C4015A429C41C51007448A8 /* UIStackView+Extension.swift in Sources */,
@@ -744,6 +768,7 @@
 				3C23C30129BB2F7A00802CEC /* LocationRepository.swift in Sources */,
 				3CB4B60129C6A1830012BBB1 /* EditViewModel.swift in Sources */,
 				3C4015B429C4AF63007448A8 /* AddViewModel.swift in Sources */,
+				3C244F8A29C845D4007FCA2E /* DetailCoordinator.swift in Sources */,
 				3CFA1E1929C5FA060024BA3C /* ListFetchRequest.swift in Sources */,
 				3C13A7FD29B9B6BC00E2FB03 /* LocationData.swift in Sources */,
 				3C13A7FB29B9B3AB00E2FB03 /* ProductPage.swift in Sources */,
@@ -757,6 +782,7 @@
 				3CB4B60529C6A33B0012BBB1 /* EditPatchRequest.swift in Sources */,
 				3C23C2E529BB10A300802CEC /* URLComponents+Extension.swift in Sources */,
 				3C23C30829BC1D1000802CEC /* FetchProductListUseCase.swift in Sources */,
+				3C244F8E29C84605007FCA2E /* EditCoordinator.swift in Sources */,
 				3CA09F5329C7673600C51452 /* DeleteProductUseCase.swift in Sources */,
 				3C40159829C1AD23007448A8 /* HeaderView.swift in Sources */,
 				3C13A7F929B9B1B600E2FB03 /* Product.swift in Sources */,
@@ -765,6 +791,8 @@
 				3CA09F4D29C75F4C00C51452 /* DeleteDataRequest.swift in Sources */,
 				3CB7C83929BC8E5E001E7992 /* LoadImageUseCase.swift in Sources */,
 				3CFA1E1429C596650024BA3C /* PostProductUseCase.swift in Sources */,
+				3C244F8829C845BF007FCA2E /* ListCoordinator.swift in Sources */,
+				3C244F8629C8458A007FCA2E /* Coordinator.swift in Sources */,
 				3C13A7E129B9A74300E2FB03 /* AppDelegate.swift in Sources */,
 				3CB7C83329BC8986001E7992 /* ListCollectionViewCell.swift in Sources */,
 				3C244F7F29C820A2007FCA2E /* ServiceDIContainer.swift in Sources */,

--- a/K-Market/K-Market.xcodeproj/project.pbxproj
+++ b/K-Market/K-Market.xcodeproj/project.pbxproj
@@ -31,6 +31,8 @@
 		3C23C30529BC13E100802CEC /* DefaultLocationRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C23C30429BC13E100802CEC /* DefaultLocationRepository.swift */; };
 		3C23C30829BC1D1000802CEC /* FetchProductListUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C23C30729BC1D1000802CEC /* FetchProductListUseCase.swift */; };
 		3C23C30E29BC1EE000802CEC /* DecodeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C23C30D29BC1EE000802CEC /* DecodeManager.swift */; };
+		3C244F7F29C820A2007FCA2E /* ServiceDIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C244F7E29C820A2007FCA2E /* ServiceDIContainer.swift */; };
+		3C244F8129C820F5007FCA2E /* SceneDIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C244F8029C820F5007FCA2E /* SceneDIContainer.swift */; };
 		3C28EF1829C0B86D00F60F2D /* UILabel+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C28EF1729C0B86D00F60F2D /* UILabel+Extension.swift */; };
 		3C40159829C1AD23007448A8 /* HeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C40159729C1AD23007448A8 /* HeaderView.swift */; };
 		3C40159B29C2E92C007448A8 /* Observabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C40159A29C2E92C007448A8 /* Observabel.swift */; };
@@ -114,6 +116,8 @@
 		3C23C30429BC13E100802CEC /* DefaultLocationRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultLocationRepository.swift; sourceTree = "<group>"; };
 		3C23C30729BC1D1000802CEC /* FetchProductListUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchProductListUseCase.swift; sourceTree = "<group>"; };
 		3C23C30D29BC1EE000802CEC /* DecodeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecodeManager.swift; sourceTree = "<group>"; };
+		3C244F7E29C820A2007FCA2E /* ServiceDIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceDIContainer.swift; sourceTree = "<group>"; };
+		3C244F8029C820F5007FCA2E /* SceneDIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDIContainer.swift; sourceTree = "<group>"; };
 		3C28EF1729C0B86D00F60F2D /* UILabel+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+Extension.swift"; sourceTree = "<group>"; };
 		3C40159729C1AD23007448A8 /* HeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderView.swift; sourceTree = "<group>"; };
 		3C40159A29C2E92C007448A8 /* Observabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Observabel.swift; sourceTree = "<group>"; };
@@ -222,6 +226,7 @@
 		3C13A7F529B9AD8E00E2FB03 /* Source */ = {
 			isa = PBXGroup;
 			children = (
+				3C244F7D29C8206A007FCA2E /* DIContainer */,
 				3C13A80829B9CC6500E2FB03 /* Util */,
 				3C13A7F629B9AD9800E2FB03 /* Application */,
 				3CB7C82029BC2CB5001E7992 /* Present */,
@@ -377,6 +382,15 @@
 				3C23C30D29BC1EE000802CEC /* DecodeManager.swift */,
 			);
 			path = Translator;
+			sourceTree = "<group>";
+		};
+		3C244F7D29C8206A007FCA2E /* DIContainer */ = {
+			isa = PBXGroup;
+			children = (
+				3C244F7E29C820A2007FCA2E /* ServiceDIContainer.swift */,
+				3C244F8029C820F5007FCA2E /* SceneDIContainer.swift */,
+			);
+			path = DIContainer;
 			sourceTree = "<group>";
 		};
 		3C40159929C2E91A007448A8 /* Type */ = {
@@ -753,6 +767,7 @@
 				3CFA1E1429C596650024BA3C /* PostProductUseCase.swift in Sources */,
 				3C13A7E129B9A74300E2FB03 /* AppDelegate.swift in Sources */,
 				3CB7C83329BC8986001E7992 /* ListCollectionViewCell.swift in Sources */,
+				3C244F7F29C820A2007FCA2E /* ServiceDIContainer.swift in Sources */,
 				3CB7C83529BC8993001E7992 /* GridCollectionViewCell.swift in Sources */,
 				3CB7C83729BC8C57001E7992 /* ProductCellViewModel.swift in Sources */,
 				3C23C30529BC13E100802CEC /* DefaultLocationRepository.swift in Sources */,
@@ -763,6 +778,7 @@
 				3CB4B60F29C6AE480012BBB1 /* EditView.swift in Sources */,
 				3C13A7E329B9A74300E2FB03 /* SceneDelegate.swift in Sources */,
 				3C4015AB29C44775007448A8 /* FetchProductDetailUseCase.swift in Sources */,
+				3C244F8129C820F5007FCA2E /* SceneDIContainer.swift in Sources */,
 				3CFA1E1D29C5FA5D0024BA3C /* ImageLoadRequest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/K-Market/K-Market/Source/Application/SceneDelegate.swift
+++ b/K-Market/K-Market/Source/Application/SceneDelegate.swift
@@ -18,10 +18,14 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         guard let windowScene = (scene as? UIWindowScene) else { return }
         let window = UIWindow(windowScene: windowScene)
+        let navigationController = UINavigationController()
         
-        let viewModel = DefaultListViewModel(fetchUseCase: DefaultFetchProductUseCase(productRepository: DefaultProductRepository(networkService: DefaultNetworkSevice())))
+        let coordinator = DefaultCoordinator(
+            navigationController: navigationController,
+            serviceDIContainer: ServiceDiContainer()
+        )
         
-        let navigationController = UINavigationController(rootViewController: ListViewController(viewModel: viewModel))
+        coordinator.start()
         
         window.rootViewController = navigationController
         window.makeKeyAndVisible()

--- a/K-Market/K-Market/Source/Coordinator/AddCoordinator.swift
+++ b/K-Market/K-Market/Source/Coordinator/AddCoordinator.swift
@@ -1,0 +1,49 @@
+//
+//  AddCoordinator.swift
+//  K-Market
+//
+//  Created by parkhyo on 2023/03/20.
+//
+
+import UIKit
+
+protocol AddCoordinator: Coordinator {
+    func didFinish()
+}
+
+final class DefaultAddCoordinator: AddCoordinator {
+    var parentCoordinator: ListCoordinator?
+    var childCoordinators = [Coordinator]()
+    var navigationController: UINavigationController
+    
+    private let locale: String
+    private let subLocale: String
+    
+    private let sceneDIContainer: SceneViewModelDependencies
+    
+    init(
+        locale: String,
+        subLocale: String,
+        navigationController: UINavigationController,
+        sceneDIContainer: SceneViewModelDependencies
+    ) {
+        self.locale = locale
+        self.subLocale = subLocale
+        self.navigationController = navigationController
+        self.sceneDIContainer = sceneDIContainer
+    }
+    
+    func start() {
+        let viewController = AddViewController(
+            viewModel: sceneDIContainer.makeAddViewModel(locale: locale, subLocale: subLocale)
+        )
+        
+        viewController.coordinator = self
+        
+        navigationController.pushViewController(viewController, animated: true)
+    }
+
+    func didFinish() {
+        parentCoordinator?.childDidFinish(self)
+    }
+}

--- a/K-Market/K-Market/Source/Coordinator/Coordinator.swift
+++ b/K-Market/K-Market/Source/Coordinator/Coordinator.swift
@@ -1,0 +1,42 @@
+//
+//  Coordinator.swift
+//  K-Market
+//
+//  Created by parkhyo on 2023/03/20.
+//
+
+import UIKit
+
+protocol Coordinator: AnyObject {
+    var childCoordinators: [Coordinator] { get set }
+    var navigationController: UINavigationController { get set }
+    
+    func start()
+}
+
+final class DefaultCoordinator: Coordinator {
+    var parentCoordinator: Coordinator? = nil
+    var childCoordinators = [Coordinator]()
+    var navigationController: UINavigationController
+    
+    private let serviceDIContainer: ServiceDiContainer
+    
+    init(navigationController: UINavigationController,
+         serviceDIContainer: ServiceDiContainer
+    ) {
+        self.navigationController = navigationController
+        self.serviceDIContainer = serviceDIContainer
+    }
+    
+    func start() {
+        let listCoordinator = DefaultListCoordinator(
+            navigationController: navigationController,
+            sceneDIContainer: serviceDIContainer.makeSceneDIContainer()
+        )
+        
+        listCoordinator.parentCoordinator = self
+        childCoordinators.append(listCoordinator)
+        
+        listCoordinator.start()
+    }
+}

--- a/K-Market/K-Market/Source/Coordinator/DetailCoordinator.swift
+++ b/K-Market/K-Market/Source/Coordinator/DetailCoordinator.swift
@@ -1,0 +1,69 @@
+//
+//  DetailCoordinator.swift
+//  K-Market
+//
+//  Created by parkhyo on 2023/03/20.
+//
+
+import UIKit
+
+protocol DetailCoordinator: Coordinator {
+    func makeEditCoordinator(product: Product, imageDatas: [Data])
+    func childDidFinish(_ child: Coordinator?)
+    func didFinish()
+}
+
+final class DefaultDetailCoordinator: DetailCoordinator {
+    var parentCoordinator: ListCoordinator?
+    var childCoordinators = [Coordinator]()
+    var navigationController: UINavigationController
+    
+    private let id: Int
+    
+    private let sceneDIContainer: SceneViewModelDependencies
+    
+    init(
+        id: Int,
+        navigationController: UINavigationController,
+        sceneDIContainer: SceneViewModelDependencies
+    ) {
+        self.id = id
+        self.navigationController = navigationController
+        self.sceneDIContainer = sceneDIContainer
+    }
+    
+    func start() {
+        let viewController = DetailViewController(viewModel: sceneDIContainer.makeDetailViewModel(id: id))
+        
+        viewController.coordinator = self
+        
+        navigationController.pushViewController(viewController, animated: true)
+    }
+    
+    func makeEditCoordinator(product: Product, imageDatas: [Data]) {
+        let coordinator = DefaultEditCoordinator(
+            product: product,
+            imageDatas: imageDatas,
+            navigationController: navigationController,
+            sceneDIContainer: sceneDIContainer
+        )
+        
+        coordinator.parentCoordinator = self
+        childCoordinators.append(coordinator)
+        
+        coordinator.start()
+    }
+    
+    func childDidFinish(_ child: Coordinator?) {
+        for (index, coordinator) in childCoordinators.enumerated() {
+            if coordinator === child {
+                childCoordinators.remove(at: index)
+                break
+            }
+        }
+    }
+    
+    func didFinish() {
+        parentCoordinator?.childDidFinish(self)
+    }
+}

--- a/K-Market/K-Market/Source/Coordinator/EditCoordinator.swift
+++ b/K-Market/K-Market/Source/Coordinator/EditCoordinator.swift
@@ -1,0 +1,49 @@
+//
+//  EditCoordinator.swift
+//  K-Market
+//
+//  Created by parkhyo on 2023/03/20.
+//
+
+import UIKit
+
+protocol EditCoordinator: Coordinator {
+    func didFinish()
+}
+
+final class DefaultEditCoordinator: EditCoordinator {
+    var parentCoordinator: DetailCoordinator?
+    var childCoordinators = [Coordinator]()
+    var navigationController: UINavigationController
+    
+    private let product: Product
+    private let imageDatas: [Data]
+    
+    private let sceneDIContainer: SceneViewModelDependencies
+    
+    init(
+        product: Product,
+        imageDatas: [Data],
+        navigationController: UINavigationController,
+        sceneDIContainer: SceneViewModelDependencies
+    ) {
+        self.product = product
+        self.imageDatas = imageDatas
+        self.navigationController = navigationController
+        self.sceneDIContainer = sceneDIContainer
+    }
+    
+    func start() {
+        let viewController = EditViewController(
+            viewModel: sceneDIContainer.makeEditViewModel(product: product, imagesData: imageDatas)
+        )
+        
+        viewController.coordinator = self
+        
+        navigationController.pushViewController(viewController, animated: true)
+    }
+
+    func didFinish() {
+        parentCoordinator?.childDidFinish(self)
+    }
+}

--- a/K-Market/K-Market/Source/Coordinator/ListCoordinator.swift
+++ b/K-Market/K-Market/Source/Coordinator/ListCoordinator.swift
@@ -1,0 +1,73 @@
+//
+//  ListCoordinator.swift
+//  K-Market
+//
+//  Created by parkhyo on 2023/03/20.
+//
+
+import UIKit
+
+protocol ListCoordinator: Coordinator {
+    func makeDetailCoordinator(id: Int)
+    func makeAddCoordinator(locale: String, subLocale: String)
+    func childDidFinish(_ child: Coordinator?)
+}
+
+final class DefaultListCoordinator: ListCoordinator {
+    var parentCoordinator: Coordinator?
+    var childCoordinators = [Coordinator]()
+    var navigationController: UINavigationController
+    
+    private let sceneDIContainer: SceneViewModelDependencies
+    
+    init(
+        navigationController: UINavigationController,
+        sceneDIContainer: SceneViewModelDependencies
+    ) {
+        self.navigationController = navigationController
+        self.sceneDIContainer = sceneDIContainer
+    }
+    
+    func start() {
+        let viewController = ListViewController(viewModel: sceneDIContainer.makeListViewModel())
+        viewController.coordinator = self
+        
+        navigationController.pushViewController(viewController, animated: true)
+    }
+    
+    func makeDetailCoordinator(id: Int) {
+        let coordinator = DefaultDetailCoordinator(
+            id: id,
+            navigationController: navigationController,
+            sceneDIContainer: sceneDIContainer
+        )
+        
+        coordinator.parentCoordinator = self
+        childCoordinators.append(coordinator)
+        
+        coordinator.start()
+    }
+    
+    func makeAddCoordinator(locale: String, subLocale: String) {
+        let coordinator = DefaultAddCoordinator(
+            locale: locale,
+            subLocale: subLocale,
+            navigationController: navigationController,
+            sceneDIContainer: sceneDIContainer
+        )
+        
+        coordinator.parentCoordinator = self
+        childCoordinators.append(coordinator)
+        
+        coordinator.start()
+    }
+    
+    func childDidFinish(_ child: Coordinator?) {
+        for (index, coordinator) in childCoordinators.enumerated() {
+            if coordinator === child {
+                childCoordinators.remove(at: index)
+                break
+            }
+        }
+    }
+}

--- a/K-Market/K-Market/Source/DIContainer/SceneDIContainer.swift
+++ b/K-Market/K-Market/Source/DIContainer/SceneDIContainer.swift
@@ -1,0 +1,113 @@
+//
+//  UseCaseDIContainer.swift
+//  K-Market
+//
+//  Created by parkhyo on 2023/03/20.
+//
+
+import Foundation
+
+final class SceneDIContainer {
+    struct ServiceDependencies {
+        let apiDataService: NetworkSevice
+        let locationDataService: FireBaseService
+    }
+    
+    private let serviceDependencies: ServiceDependencies
+    
+    private lazy var productRepository: ProductRepository = makeProductRepository()
+    private lazy var locationRepository: LocationRepository = makeLocationRepository()
+    
+    init(serviceDependencies: ServiceDependencies) {
+        self.serviceDependencies = serviceDependencies
+    }
+    
+    // MARK: - Make Repository
+    func makeProductRepository() -> ProductRepository {
+        return DefaultProductRepository(networkService: serviceDependencies.apiDataService)
+    }
+    
+    func makeLocationRepository() -> LocationRepository {
+        return DefaultLocationRepository(service: serviceDependencies.locationDataService)
+    }
+    
+    // MARK: - Make UseCase
+    func makeLoadImageUseCase() -> LoadImageUseCase {
+        return DefaultLoadImageUseCase(productRepository: productRepository)
+    }
+    
+    func makeFetchProductListUseCase() -> FetchProductListUseCase {
+        return DefaultFetchProductUseCase(productRepository: productRepository)
+    }
+    
+    func makeFetchLocationUseCase() -> FetchLocationUseCase {
+        return DefaultFetchLocationDataUseCase(locationRepository: locationRepository)
+    }
+    
+    func makeFetchProductDetailUseCase() -> FetchProductDetailUseCase {
+        return DefaultFetchProductDetailUseCase(productRepository: productRepository)
+    }
+    
+    func makePostProductUseCase() -> PostProductUseCase {
+        return DefaultPostProductUseCase(productRepository: productRepository)
+    }
+    
+    func makePostLocationUseCase() -> PostLocationUseCase {
+        return DefaultPostLocationUseCase(locationRepository: locationRepository)
+    }
+    
+    func makePatchProductUseCase() -> PatchProductUseCase {
+        return DefaultPatchProductUseCase(productRepository: productRepository)
+    }
+    
+    func makeDeleteProductUseCase() -> DeleteProductUseCase {
+        return DefaultDeleteProductUseCase(productRepository: productRepository)
+    }
+    
+    func makeDeleteLocationUseCase() -> DeleteLocationUseCase {
+        return DefaultDeleteLocationUseCase(locationRepository: locationRepository)
+    }
+}
+
+extension SceneDIContainer: SceneViewModelDependencies {
+    // MARK: - Make ViewModel
+    func makeListViewModel() -> ListViewModel {
+        return DefaultListViewModel(
+            fetchUseCase: makeFetchProductListUseCase(),
+            fetchLocationUseCase: makeFetchLocationUseCase()
+        )
+    }
+    
+    func makeDetailViewModel(id: Int) -> DetailViewModel {
+        return DefaultDetailViewModel(
+            id: id,
+            fetchLocationUseCase: makeFetchLocationUseCase(),
+            fetchProductDetailUseCase: makeFetchProductDetailUseCase(),
+            loadImageUseCase: makeLoadImageUseCase(),
+            deleteProductUseCase: makeDeleteProductUseCase(),
+            deleteLocationUseCase: makeDeleteLocationUseCase()
+        )
+    }
+    
+    func makeAddViewModel(locale: String, subLocale: String) -> AddViewModel {
+        return DefaultAddViewModel(
+            locale: locale,
+            subLocale: subLocale,
+            postProductUseCase: makePostProductUseCase(),
+            postLocationUseCase: makePostLocationUseCase(),
+            loadImageUseCase: makeLoadImageUseCase()
+        )
+    }
+    
+    func makeEditViewModel(product: Product, imagesData: [Data]) -> EditViewModel {
+        return DefaultEditViewModel(
+            product: product, imagesData: imagesData, patchProductUseCase: makePatchProductUseCase())
+    }
+}
+
+protocol SceneViewModelDependencies {
+    func makeListViewModel() -> ListViewModel
+    func makeDetailViewModel(id: Int) -> DetailViewModel
+    func makeAddViewModel(locale: String, subLocale: String) -> AddViewModel
+    func makeEditViewModel(product: Product, imagesData: [Data]) -> EditViewModel
+}

--- a/K-Market/K-Market/Source/DIContainer/SceneDIContainer.swift
+++ b/K-Market/K-Market/Source/DIContainer/SceneDIContainer.swift
@@ -74,6 +74,7 @@ extension SceneDIContainer: SceneViewModelDependencies {
     func makeListViewModel() -> ListViewModel {
         return DefaultListViewModel(
             fetchUseCase: makeFetchProductListUseCase(),
+            loadImageUseCase: makeLoadImageUseCase(),
             fetchLocationUseCase: makeFetchLocationUseCase()
         )
     }

--- a/K-Market/K-Market/Source/DIContainer/ServiceDIContainer.swift
+++ b/K-Market/K-Market/Source/DIContainer/ServiceDIContainer.swift
@@ -1,0 +1,23 @@
+//
+//  ServiceDIContainer.swift
+//  K-Market
+//
+//  Created by parkhyo on 2023/03/20.
+//
+
+import Foundation
+
+final class ServiceDiContainer {
+    private let apiDataService: NetworkSevice = DefaultNetworkSevice()
+    private let locationDataService: FireBaseService = DefaultFireBaseService()
+    
+    // MARK: - DIContainers of Scenes
+    func makeSceneDIContainer() -> SceneDIContainer {
+        let dependencies = SceneDIContainer.ServiceDependencies(
+            apiDataService: apiDataService,
+            locationDataService: locationDataService
+        )
+        
+        return SceneDIContainer(serviceDependencies: dependencies)
+    }
+}

--- a/K-Market/K-Market/Source/Present/AddScene/View/AddViewController.swift
+++ b/K-Market/K-Market/Source/Present/AddScene/View/AddViewController.swift
@@ -8,12 +8,19 @@
 import UIKit
 
 final class AddViewController: UIViewController {
+    weak var coordinator: AddCoordinator?
+    
     private let addView: AddView
     private let viewModel: AddViewModel
     private let picker = UIImagePickerController()
     
     override func viewDidLoad() {
         super.viewDidLoad()
+    }
+    
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        coordinator?.didFinish()
     }
     
     init(viewModel: AddViewModel) {

--- a/K-Market/K-Market/Source/Present/DetailScene/View/DetailViewController.swift
+++ b/K-Market/K-Market/Source/Present/DetailScene/View/DetailViewController.swift
@@ -8,6 +8,8 @@
 import UIKit
 
 final class DetailViewController: UIViewController {
+    weak var coordinator: DetailCoordinator?
+    
     private let viewModel: DetailViewModel
     private let productInfoView: ProductInfoView
     
@@ -45,7 +47,9 @@ final class DetailViewController: UIViewController {
     }
     
     override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
         viewModel.clear()
+        coordinator?.didFinish()
     }
     
     init(viewModel: DetailViewModel) {
@@ -167,15 +171,8 @@ extension DetailViewController {
         
         let editAction = UIAlertAction(title: "수정", style: .default) { _ in
             guard let product = self.viewModel.product.value else { return }
-            let viewModel = DefaultEditViewModel(
-                product: product,
-                imagesData: self.viewModel.imageDatas,
-                patchProductUseCase: DefaultPatchProductUseCase(
-                    productRepository: DefaultProductRepository(networkService: DefaultNetworkSevice()))
-            )
-            let editViewController = EditViewController(viewModel: viewModel)
             
-            self.navigationController?.pushViewController(editViewController, animated: true)
+            self.coordinator?.makeEditCoordinator(product: product, imageDatas: self.viewModel.imageDatas)
         }
         
         let deleteAction = UIAlertAction(title: "삭제", style: .default) { _ in

--- a/K-Market/K-Market/Source/Present/EditScene/View/EditViewController.swift
+++ b/K-Market/K-Market/Source/Present/EditScene/View/EditViewController.swift
@@ -8,11 +8,18 @@
 import UIKit
 
 final class EditViewController: UIViewController {
+    weak var coordinator: EditCoordinator?
+    
     private let viewModel: EditViewModel
     private let editView: EditView
 
     override func viewDidLoad() {
         super.viewDidLoad()
+    }
+    
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        coordinator?.didFinish()
     }
 
     init(viewModel: EditViewModel) {

--- a/K-Market/K-Market/Source/Present/MainScene/View/ListViewController.swift
+++ b/K-Market/K-Market/Source/Present/MainScene/View/ListViewController.swift
@@ -21,6 +21,8 @@ final class ListViewController: UIViewController {
         case main
     }
     
+    weak var coordinator: ListCoordinator?
+    
     private lazy var dataSource = configureDataSource()
     private lazy var collectionView: UICollectionView = {
         let collectionView = UICollectionView(
@@ -65,36 +67,15 @@ final class ListViewController: UIViewController {
 
 extension ListViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        let detailView = DetailViewController(viewModel: DefaultDetailViewModel(
-            id: viewModel.productList.value[indexPath.item].id,
-            fetchLocationUseCase: DefaultFetchLocationDataUseCase(locationRepository: DefaultLocationRepository(service: DefaultFireBaseService())),
-            fetchProductDetailUseCase: DefaultFetchProductDetailUseCase(productRepository: DefaultProductRepository(networkService: DefaultNetworkSevice())),
-            loadImageUseCase: DefaultLoadImageUseCase(productRepository: DefaultProductRepository(networkService: DefaultNetworkSevice())),
-            deleteProductUseCase: DefaultDeleteProductUseCase(productRepository: DefaultProductRepository(networkService: DefaultNetworkSevice())),
-            deleteLocationUseCase: DefaultDeleteLocationUseCase(locationRepository: DefaultLocationRepository(service: DefaultFireBaseService()))
-        )
-                                              
-        )
-        
-        navigationController?.pushViewController(detailView, animated: true)
+        let id = viewModel.productList.value[indexPath.item].id
+        coordinator?.makeDetailCoordinator(id: id)
     }
 }
-
 
 // MARK: - Action
 extension ListViewController {
     @objc private func addButtonTapped() {
-        let addViewModel = DefaultAddViewModel(
-            locale: viewModel.userLocale,
-            subLocale: viewModel.userSubLocale.value,
-            postProductUseCase: DefaultPostProductUseCase(productRepository: DefaultProductRepository(networkService: DefaultNetworkSevice())),
-            postLocationUseCase: DefaultPostLocationUseCase(locationRepository: DefaultLocationRepository(service: DefaultFireBaseService())),
-            loadImageUseCase: DefaultLoadImageUseCase(productRepository: DefaultProductRepository(networkService: DefaultNetworkSevice())))
-        
-        let addViewController = AddViewController(viewModel: addViewModel)
-        
-        addViewController.modalPresentationStyle = .fullScreen
-        navigationController?.pushViewController(addViewController, animated: true)
+        coordinator?.makeAddCoordinator(locale: viewModel.userLocale, subLocale: viewModel.userSubLocale.value)
     }
 }
 
@@ -147,16 +128,8 @@ extension ListViewController {
             
             let cellViewModel = DefaultProductCellViewModel(
                 product: data,
-                loadImageUseCase: DefaultLoadImageUseCase(
-                    productRepository: DefaultProductRepository(
-                        networkService: DefaultNetworkSevice()
-                    )
-                ),
-                fetchLocationUseCase: DefaultFetchLocationDataUseCase(
-                    locationRepository: DefaultLocationRepository(
-                        service: DefaultFireBaseService()
-                    )
-                )
+                loadImageUseCase: self.viewModel.loadImageUseCase,
+                fetchLocationUseCase: self.viewModel.fetchLocationUseCase
             )
             
             cell.setupViewModel(cellViewModel)

--- a/K-Market/K-Market/Source/Present/MainScene/ViewModel/ListViewModel.swift
+++ b/K-Market/K-Market/Source/Present/MainScene/ViewModel/ListViewModel.swift
@@ -18,6 +18,8 @@ protocol ListViewModelOutput {
     var productList: Observable<[Product]> { get }
     var userSubLocale: Observable<String> { get }
     var userLocale: String { get }
+    var loadImageUseCase: LoadImageUseCase { get }
+    var fetchLocationUseCase: FetchLocationUseCase { get }
     var layoutStatus: Observable<CollectionType> { get }
     
     func fetchLayoutStatus() -> CollectionType
@@ -28,13 +30,21 @@ protocol ListViewModel: ListViewModelInput, ListViewModelOutput  { }
 final class DefaultListViewModel: ListViewModel {
     private(set) var userLocale = ""
     private let fetchUseCase: FetchProductListUseCase
+    private(set) var loadImageUseCase: LoadImageUseCase
+    private(set) var fetchLocationUseCase: FetchLocationUseCase
     
     var productList = Observable<[Product]>([])
     var userSubLocale = Observable<String>(Constant.reject)
     var layoutStatus = Observable<CollectionType>(.list)
     
-    init(fetchUseCase: FetchProductListUseCase) {
+    init(
+        fetchUseCase: FetchProductListUseCase,
+        loadImageUseCase: LoadImageUseCase,
+        fetchLocationUseCase: FetchLocationUseCase
+    ) {
         self.fetchUseCase = fetchUseCase
+        self.loadImageUseCase = loadImageUseCase
+        self.fetchLocationUseCase = fetchLocationUseCase
     }
     
     func clear() {


### PR DESCRIPTION
내용
- [x] View의 화면이동을 Coordinator을 통해서 구현
- Service 주입을 위해 ServiceDIContainer라는 타입을 별도로 구현.
- Repository, UseCase 주입을 위해 SceneDIContainer라는 타입을 별도로 구현.
- ViewModel 주입을 위해 SceneViewModelDependencies라는 프로토콜을 정의하여 SceneDIContainer가 채택하게 끔 구현.
- 각 Scene에 해당하는 Coordinator들은 SceneDIContainer가 아닌 SceneViewModelDependencies를 바라보고 있게끔 구현
이유 : 각 Scene에 해당하는 Coordinator들은 ViewModel 주입 외에 관여를 안하게 하기 위해서이다.
